### PR TITLE
Update liveimage-mount.

### DIFF
--- a/tools/liveimage-mount
+++ b/tools/liveimage-mount
@@ -1,9 +1,10 @@
 #!/usr/bin/python -tt
+# coding: latin-1
+# 2015-05-27 16:30:26
 #
-# liveimage-mount: Mount a LiveOS at the specified point, and log
-# into a shell.
+# liveimage-mount: Mount a LiveOS at the specified point, and log into a shell.
 #
-# Copyright 2011, Red Hat  Inc.
+# Copyright 2011, Red Hat  Inc., Sugar Labs®
 #   Code for Live mounting an attached LiveOS device added by Frederick Grose,
 #   <fgrose at sugarlabs.org>
 #
@@ -27,20 +28,32 @@ import getopt
 import tempfile
 import subprocess
 
-from imgcreate.errors import *
-
 def usage(ecode):
     print """Usage:
-        liveimage-mount [opts] ISO.iso|LiveOSdevice MOUNTPOINT [COMMAND] [ARGS]
+       liveimage-mount [opts] ISO.iso|LiveOSdev|dir MOUNTPOINT [COMMAND] [ARGS]
 
                   where [opts] = [-h|--help
                                  [--chroot
                                  [--mount-hacks
-                                 [--persist]]]]]
+                                 [--persist
+                                 [-y|--yumcache=YUMCACHEPATH
+                                 [-d|--dnfcache=DNFCACHEPATH]]]]]]
 
                     and [ARGS] = [arg1[ arg2[ ...]]]\n"""
     sys.exit(ecode)
 
+class LiveImageMountError(Exception):
+    """An exception base class for all liveimage-mount errors."""
+    def __init__(self, msg):
+        Exception.__init__(self, msg)
+    def __str__(self):
+        try:
+            return str(self.message)
+        except UnicodeEncodeError:
+            return repr(self.message)
+
+    def __unicode__(self):
+        return unicode(self.message)
 
 def call(*popenargs, **kwargs):
     '''
@@ -63,43 +76,69 @@ def call(*popenargs, **kwargs):
     return rc
 
 
-def rcall(args, env=None):
-    if env:
+def rcall(args, stdin=None, rpterr=True, env=None):
+    '''Return stdout, stderr, & returncode from a subprocess call.'''
+
+    out, err, p, environ = '', '', None, None
+    if env is not None:
         environ = os.environ.copy()
         environ.update(env)
-    else:
-        environ = None
     try:
-        p = subprocess.Popen(args, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE, env=environ)
-        out, err = p.communicate()
-    except OSError, e:
-        raise CreatorError(u"Failed to execute:\n'%s'\n'%s'" % (args, e))
-    except:
-        raise CreatorError(u"""Failed to execute:\n'%s'
-            \renviron: '%s'\nstdout: '%s'\nstderr: '%s'\nreturncode: '%s'""" %
-            (args, environ, out, err, p.returncode))
+        p = subprocess.Popen(args, stdin=subprocess.PIPE, env=environ,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate(stdin)
+    except OSError as e:
+        out, err = out, u'Failed executing:\n%s\nerror: %s' % (args, e)
+        if rpterr:
+            raise LiveImageMountError(u'Failed executing:\n%s\nerror: %s' %
+                                      (args, e))
+    except Exception as e:
+        out, err = (out, u'Failed to execute:\n%s\nerror: %s' %
+                          (args, e))
+        if raise_err:
+            raise LiveImageMountError(u'''Failed to execute:\n%s
+                                      \rerror: %s\nstdout: %s\nstderr: %s''' %
+                                      (args, e, out, err))
     else:
-        if p.returncode != 0:
-            raise CreatorError(u"""Error in call:\n'%s'\nenviron: '%s'
-                \rstdout: '%s'\nstderr: '%s'\nreturncode: '%s'""" %
-                (args, environ, out, err, p.returncode))
-        return out
+        if p.returncode != 0 and rpterr:
+            raise LiveImageMountError(u'''Error in call:\n%s\nenviron: %s
+                               \rstdout: %s\nstderr: %s\nreturncode: %s''' %
+                               (args, environ, out, err, p.returncode))
+    finally:
+        return out, err
 
 
-def get_device_mountpoint(path):
-    """Return the device and mountpoint for a file or device path."""
+def get_fsvalue(format=None, tag=None, token=None, filesystem=None):
+    """Return filesystem information based on a blkid tag, token, or device."""
 
-    info = list()
-    info[0:5] = [None] * 6
-    if os.path.exists(path):
-        st_mode = os.stat(path).st_mode
-        if stat.S_ISBLK(st_mode) or os.path.ismount(path):
-            devinfo = rcall(['/bin/df', path]).splitlines()
-            info = devinfo[1].split(None)
-            if len(info) == 1:
-                info.extend(devinfo[2].split(None))
-    return [info[0], info[5]]
+    dev_null = os.open('/dev/null', os.O_WRONLY)
+    args = ['blkid', '-c', '/dev/null']
+    if format:
+        args.extend(['-o', format])
+    if tag:
+        args.extend(['-s', tag])
+    if token:
+        args.extend(['-l', '-t', token])
+    if filesystem:
+        args.extend([filesystem])
+    try:
+        fs_value = subprocess.Popen(args,
+                               stdout=subprocess.PIPE,
+                               stderr=dev_null).communicate()[0].rstrip()
+    except IOError, e:
+        raise LiveImageMountError("Failed to determine fs %s: %s" % value, e)
+    finally:
+        os.close(dev_null)
+    return fs_value
+
+
+def loop_setup(path, ops=None):
+    """Make and associate a loop device with an image file or device."""
+
+    args = ['losetup', '-f', '--show', path]
+    if ops is not None:
+        args += ops
+    return rcall(args)[0].rstrip()
 
 
 def main():
@@ -109,131 +148,171 @@ def main():
         return 1
 
     try:
-        opts,args = getopt.getopt(sys.argv[1:], 'h', ['help',
-                                                       'chroot', 'persist',
-                                                       'mount-hacks'])
+        opts, args = getopt.getopt(sys.argv[1:], 'hy:d:', ['help', 'chroot',
+                          'persist', 'mount-hacks', 'yumcache=', 'dnfcache='])
     except getopt.GetoptError, e:
         usage(1)
 
-    img_type = None
     chroot = False
-    persist = False
     mount_hacks = False
-    for o,a in opts:
+    persist = False
+    yumcache = None
+    dnfcache = None
+    for o, a in opts:
         if o in ('-h', '--help'):
             usage(0)
-        elif o in ('--chroot', ):
+        elif o in ('--chroot',):
             chroot = True
-        elif o in ('--mount-hacks', ):
+        elif o in ('--mount-hacks',):
             mount_hacks = True
-        elif o in ('--persist', ):
+        elif o in ('--persist',):
             """Option used to run a command in a spawned process."""
             persist = True
+        elif o in ('-y', '--yumcache'):
+            yumcache = a
+        elif o in ('-d', '--dnfcache'):
+            dnfcache = a
 
     if len(args) < 2:
         usage(1)
 
     liveos = args[0]
     destmnt = args[1]
-
+    if not os.path.isdir(destmnt):
+        os.makedirs(destmnt)
+        rm_mnt = destmnt
+    if os.path.ismount(destmnt):
+        print """\n     Exiting...
+        %s is already in use as a mount point.\n""" % destmnt
+        ecode = 1
+        return
+        
     if not os.path.exists(liveos):
         print """\n     Exiting...
         %s is not a file, directory, or device.\n""" % liveos
         ecode = 1
         return
 
-    if stat.S_ISBLK(os.stat(liveos).st_mode):
+    liveos_stat = os.stat(liveos).st_mode
+    if stat.S_ISBLK(liveos_stat):
         img_type = 'blk'
-        imgloop = None
-        overlayloop = None
+        liveosmnt = tempfile.mkdtemp(prefix='mp-blk-', dir='/run')
+    elif stat.S_ISDIR(liveos_stat):
+        img_type = 'dir'
+        liveosmnt = liveos
     else:
         img_type = 'iso'
-
-    if img_type is 'blk':
-        liveosmnt = tempfile.mkdtemp(prefix='livemnt-device-')
-    if img_type is 'iso':
-        liveosmnt = tempfile.mkdtemp(prefix='livemnt-iso-')
+        liveosmnt = tempfile.mkdtemp(prefix='mp-iso-', dir='/run')
 
     liveosdir = os.path.join(liveosmnt, 'LiveOS')
-    homemnt = None
-    dm_cow = None
-    mntlive = None
 
     command = args[2:]
     verbose = not command
 
-    squashmnt = tempfile.mkdtemp(prefix='livemnt-squash-')
-    squashloop = None
-    imgloop = None
-    losetup_args = ['/sbin/losetup', '-f', '--show']
-
     try:
-        if img_type is 'blk':
-            call(['/bin/mount', liveos, liveosmnt])
-        elif img_type is 'iso':
-            liveosloop = rcall(losetup_args + [liveos]).rstrip()
-            call(['/bin/mount', '-o', 'ro', liveosloop, liveosmnt])
+        if img_type == 'blk':
+            call(['mount', liveos, liveosmnt])
+        elif img_type == 'iso':
+            call(['mount', '-r', liveos, liveosmnt])
 
         squash_img = os.path.join(liveosdir, 'squashfs.img')
         if not os.path.exists(squash_img):
-            ext3_img = os.path.join(liveosdir, 'ext3fs.img')
-            if not os.path.exists(ext3_img):
+            rootfs_img = os.path.join(liveosdir, 'ext3fs.img')
+            if not os.path.exists(rootfs_img):
                 print """
                 \r\tNo LiveOS was found on %s\n\t  Exiting...\n""" % liveos
                 ecode = 1
                 return
         else:
-            squashloop = rcall(losetup_args + [squash_img]).rstrip()
-            call(['/bin/mount', '-o', 'ro', squashloop, squashmnt])
-            ext3_img = os.path.join(squashmnt, 'LiveOS', 'ext3fs.img')
+            squashmnt = tempfile.mkdtemp(prefix='mp-squash-', dir='/run')
+            call(['mount', '-r', squash_img, squashmnt])
+            rootfs_img = os.path.join(squashmnt, 'LiveOS', 'ext3fs.img')
+            if not os.path.exists(rootfs_img):
+                rootfs_img = os.path.join(squashmnt, 'LiveOS', 'rootfs.img')
+            if not os.path.exists(rootfs_img):
+                print """
+                \r\tNo rootfs.img was found on %s\n\t  Exiting...\n""" % liveos
+                ecode = 1
+                return
 
-        if img_type is 'blk':
-            imgloop = rcall(losetup_args + [ext3_img]).rstrip()
-            imgsize = rcall(['/sbin/blockdev', '--getsz', imgloop]).rstrip()
-            files = os.listdir(liveosdir)
-            overlay = None
-            for f in files:
-                if f.find('overlay-') == 0:
-                    overlay = f
-                    break
-            overlayloop = rcall(['/sbin/losetup', '-f']).rstrip()
-            if overlay:
-                call(['/sbin/losetup', overlayloop, os.path.join(liveosdir,
-                                                                 overlay)])
-                dm_cow = 'live-rw'
-            else:
-                overlay = tempfile.NamedTemporaryFile(dir='/dev/shm')
-                print "\npreparing temporary overlay..."
-                call(['/bin/dd', 'if=/dev/null', 'of=%s' % overlay.name,
-                      'bs=1024', 'count=1', 'seek=%s' % (512 * 1024)])
-                call(['/sbin/losetup', overlayloop, overlay.name])
-                dm_cow = 'live-ro'
-            call(['/sbin/dmsetup', '--noudevrules', '--noudevsync',
-                 'create', dm_cow, '--table=0 %s snapshot %s %s p 8' %
-                 (imgsize, imgloop, overlayloop)])
-            call(['/bin/mount', os.path.join('/dev/mapper', dm_cow), destmnt])
-            home_path = os.path.join(liveosdir, 'home.img')
-            if os.path.exists(home_path):
-                homemnt = os.path.join(destmnt, 'home')
-                homeloop = rcall(losetup_args + [home_path]).rstrip()
-                call(['/bin/mount', homeloop, homemnt])
-            mntlive = os.path.join(destmnt, 'mnt', 'live')
-            if not os.path.exists(mntlive):
-                os.makedirs(mntlive)
-            call(['/bin/mount', '--bind', liveosmnt, mntlive])
-        elif img_type is 'iso':
-            imgloop = rcall(losetup_args + [ext3_img]).rstrip()
-            call(['/bin/mount', '-o', 'ro', imgloop, destmnt])
+        if img_type in ('blk', 'dir'):
+            imgloop = loop_setup(rootfs_img)
+        elif img_type == 'iso':
+            imgloop = loop_setup(rootfs_img, ['-r'])
+        imgsize = rcall(['blockdev', '--getsz', imgloop])[0].rstrip()
+        for f in os.listdir(liveosdir):
+            if f.find('overlay-') == 0:
+                overlay = f
+                break
+        persistent = 'P'
+        if 'overlay' in locals():
+            overlayloop = loop_setup(os.path.join(liveosdir, overlay))
+        else:
+            overlay = tempfile.NamedTemporaryFile(dir='/run')
+            print "\npreparing temporary overlay..."
+            call(['dd', 'if=/dev/null', 'of=%s' % overlay.name,
+                  'bs=1024', 'count=1', 'seek=%s' % (512 * 1024)])
+            overlayloop = loop_setup(overlay.name)
+            persistent = 'N'
+        fd, dm_cow = tempfile.mkstemp(prefix='dm-')
+        os.close(fd)
+        os.unlink(dm_cow)
+        dm_cow = os.path.basename(dm_cow)
+        call(['dmsetup', 'create', dm_cow, '--table=0 %s snapshot %s %s %s 8' %
+                                  (imgsize, imgloop, overlayloop, persistent)])
+        call(['mount', os.path.join('/dev/mapper', dm_cow), destmnt])
+        home_path = os.path.join(liveosdir, 'home.img')
+        if os.path.exists(home_path):
+            homemnt = os.path.join(destmnt, 'home')
+            homedev = loop_setup(home_path)
+            if get_fsvalue('value', 'TYPE', None,
+                           homedev) == 'crypto_LUKS':
+                call(['cryptsetup', 'luksOpen', homedev, 'EncHome'])
+                homedev = os.path.join('/dev', 'mapper', 'EncHome')
+            if img_type in ('blk', 'dir'):
+                call(['mount', homedev, homemnt])
+            elif img_type == 'iso':
+                call(['mount', '-r', homedev, homemnt])
+        mntlive = os.path.join(destmnt, 'run', 'initramfs', 'live')
+        if not os.path.exists(mntlive):
+            os.makedirs(mntlive)
+            rmmntdir = True
+        call(['mount', '--bind', liveosmnt, mntlive])
 
         if mount_hacks:
-            subprocess.check_call(['mount', '-t', 'proc', 'proc', os.path.join(destmnt, 'proc')], stderr=sys.stderr)
-            subprocess.check_call(['mount', '-t', 'tmpfs', 'tmpfs', os.path.join(destmnt, 'var', 'run')], stderr=sys.stderr)
+            subprocess.check_call(['mount', '-t', 'proc', 'proc',
+                os.path.join(destmnt, 'proc')], stderr=sys.stderr)
+            subprocess.check_call(['mount', '-t', 'sysfs', 'sys',
+                os.path.join(destmnt, 'sys')], stderr=sys.stderr)
+            subprocess.check_call(['mount', '-t', 'devpts', 'devpts',
+                os.path.join(destmnt, 'dev', 'pts')], stderr=sys.stderr)
+            tmpfs = os.path.join(destmnt, 'dev', 'shm')
+            if not os.path.exists(tmpfs):
+                os.makedirs(tmpfs)
+            subprocess.check_call(['mount', '-t', 'tmpfs', 'tmpfs', tmpfs],
+                                  stderr=sys.stderr)
+            if yumcache is not None:
+                call(['mount', '--bind', yumcache,
+                      os.path.join(destmnt, 'var', 'cache', 'yum')])
+            else:
+                subprocess.check_call(['mount', '-t', 'tmpfs', 'varcacheyum',
+                    os.path.join(destmnt, 'var', 'cache', 'yum')],
+                    stderr=sys.stderr)
+            if dnfcache is not None:
+                call(['mount', '--bind', dnfcache,
+                      os.path.join(destmnt, 'var', 'cache', 'dnf')])
+            else:
+                subprocess.check_call(['mount', '-t', 'tmpfs', 'varcachednf',
+                    os.path.join(destmnt, 'var', 'cache', 'dnf')],
+                    stderr=sys.stderr)
+            call(['mount', '--bind', '/etc/resolv.conf',
+                  os.path.join(destmnt, 'etc', 'resolv.conf')])
 
         if len(command) > 0 and persist:
             args = []
             args.extend(command)
             live = ''
-            if img_type is 'blk':
+            if img_type in ('blk', 'dir'):
                 live = 'live-'
             print """Starting process with this command line:
             \r%s\n  %s is %smounted.""" % (' '.join(command), liveos, live)
@@ -243,54 +322,66 @@ def main():
         elif len(command) > 0:
             args = ['chroot', destmnt]
             args.extend(command)
-            ecode = subprocess.call(args, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+            ecode = subprocess.call(args, stdin=sys.stdin, stdout=sys.stdout,
+                                    stderr=sys.stderr)
         elif chroot:
-            print "Starting subshell in chroot, press Ctrl-D to exit..."
-            ecode = subprocess.call(['chroot', destmnt], stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+            print "Starting subshell in chroot, press Ctrl D to exit..."
+            ecode = subprocess.call(['chroot', destmnt], stdin=sys.stdin,
+                                    stdout=sys.stdout, stderr=sys.stderr)
         else:
-            if dm_cow == 'live-ro':
+            if img_type in ('blk', 'dir') and dm_cow[:7] == 'live-ro':
                 status = ' with NO LiveOS persistence,'
             else:
                 status = ''
-            print "Entering subshell,%s press Ctrl-D to exit..." % status
-            ecode = subprocess.call([os.environ['SHELL']], cwd=destmnt, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+            print "Entering subshell,%s press Ctrl D to exit..." % status
+            ecode = subprocess.call([os.environ['SHELL']], cwd=destmnt,
+                    stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
     finally:
-        call(['/bin/sync'])
+        if verbose:
+            print """Cleaning up...
+            Please wait if large files were written."""
+        call(['sync'])
         if not persist:
-            if verbose:
-                print """Cleaning up...
-                Please wait if large files were written."""
             if mount_hacks:
-                subprocess.call(['umount', os.path.join(destmnt, 'var', 'run')])
-                subprocess.call(['umount', os.path.join(destmnt, 'proc')])
-            if homemnt:
-                call(['/bin/umount', homemnt])
-                call(['/sbin/losetup', '-d', homeloop])
-            if img_type is 'blk':
-                if mntlive:
-                    call(['/bin/umount', mntlive])
-                    os.rmdir(mntlive)
+                call(['umount', os.path.join(destmnt, 'proc'),
+                                os.path.join(destmnt, 'dev', 'pts'),
+                                os.path.join(destmnt, 'sys'),
+                                os.path.join(destmnt, 'dev', 'shm'),
+                                os.path.join(destmnt, 'var', 'cache', 'yum'),
+                                os.path.join(destmnt, 'var', 'cache', 'dnf'),
+                                os.path.join(destmnt, 'etc', 'resolv.conf')])
+
+            localdict = locals()
+            if 'homemnt' in localdict:
+                call(['umount', homemnt])
+                if homedev == os.path.join('/dev', 'mapper', 'EncHome'):
+                    call(['dmsetup', 'remove', 'EncHome'])
+                else:
+                    call(['losetup', '-d', homedev])
+            if 'mntlive' in localdict:
+                call(['umount', mntlive])
+            if 'rmmntdir' in localdict:
+                os.rmdir(mntlive)
             if os.path.ismount(destmnt):
-                call(['/bin/umount', destmnt])
-            if img_type is 'blk':
-                if dm_cow:
-                    call(['/sbin/dmsetup', '--noudevrules', '--noudevsync',
-                          'remove', dm_cow])
-                if overlayloop:
-                    call(['/sbin/losetup', '-d', overlayloop])
-            if imgloop:
-                call(['/sbin/losetup', '-d', imgloop])
-            if squashloop:
-                call(['/bin/umount', squashloop])
-                call(['/sbin/losetup', '-d', squashloop])
-            call(['/bin/umount', liveosmnt])
-            if not img_type is 'blk':
-                call(['/sbin/losetup', '-d', liveosloop])
-            os.rmdir(squashmnt)
-            if not os.path.ismount(liveosmnt):
+                os.chdir('..')
+                call(['umount', destmnt])
+            #FIXME -f force option is sometimes needed when there are
+            # multiple invocations of liveimage-mount active.
+            # Try the --retry option in place of -f (2013-01-20).
+            call(['dmsetup', 'remove', '--retry', dm_cow])
+            call(['losetup', '-d', overlayloop])
+            call(['losetup', '-d', imgloop])
+            if 'squashmnt' in localdict:
+                call(['umount', squashmnt])
+                os.rmdir(squashmnt)
+            if os.path.ismount(liveosmnt) and img_type != 'dir':
+                call(['umount', liveosmnt])
+            if not os.path.ismount(liveosmnt) and img_type != 'dir':
                 os.rmdir(liveosmnt)
+            if 'rm_mnt' in localdict:
+                os.removedirs(rm_mnt)
             if verbose:
-                print "Cleanup complete"
+                print "Cleanup complete."
 
     sys.exit(ecode)
 


### PR DESCRIPTION
Many integrated updates--best reviewed by test driving.
Provide in-file utility and error handling functions to permit standalone usage.
Include a date tag to easily distinguish in-the-wild versions.
Add support for mounting directories with LiveOS contents.
Add support for Yum and/or DNF repo caches.
Create a non-existent mount directory and remove it when done, if needed.
Use the /run tmpfs instead of /dev/shm.
Create non-persistent metadata type snapshot target for in memory overlays.
Use random device mapper and mount point names.
Support encrypted home filesystems.
Cleanup white space and line lengths.