### PR TITLE
Use add_drivers for dracut config (#1192030)

### DIFF
--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -304,7 +304,7 @@ class LiveImageCreatorBase(LoopImageCreator):
             makedirs(os.path.dirname(path))
         f = open(path, "a")
         f.write('filesystems+="' + self.__extra_filesystems() + ' "\n')
-        f.write('drivers+="' + self.__extra_drivers() + ' "\n')
+        f.write('add_drivers+="' + self.__extra_drivers() + ' "\n')
         f.write('add_dracutmodules+=" dmsquash-live pollcdrom "\n')
         f.write('hostonly="no"\n')
         f.write('dracut_rescue_image="no"\n')


### PR DESCRIPTION
Writing drivers+= to the dracut config ONLY installs those drivers. This
switches to use add_drivers+= so that dracut will pick up the usual set
of drivers and ADD the ones we select.

Resolves: rhbz#1192030