### PR TITLE
Remove unused tmpdir parameter in resize2fs().

### DIFF
--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -929,8 +929,7 @@ class LoopImageCreator(ImageCreator):
                                        self._instroot,
                                        self._fstype,
                                        self.__blocksize,
-                                       self.fslabel,
-                                       self.tmpdir)
+                                       self.fslabel)
 
         try:
             self.__instloop.mount()

--- a/imgcreate/fs.py
+++ b/imgcreate/fs.py
@@ -85,7 +85,7 @@ def mksquashfs(in_img, out_img, compress_type):
         raise SquashfsError("'%s' exited with error (%d)" %
                             (string.join(args, " "), ret))
 
-def resize2fs(fs, size = None, minimal = False, tmpdir = "/tmp"):
+def resize2fs(fs, size=None, minimal=False):
     if minimal and size is not None:
         raise ResizeError("Can't specify both minimal and a size for resize!")
     if not minimal and size is None:
@@ -213,7 +213,7 @@ class SparseExtLoopbackMount(SparseLoopbackMount):
     def __init__(self, lofile, mountdir, size, fstype, blocksize, fslabel):
         self.diskmount = ExtDiskMount(SparseLoopbackDisk(lofile,size),
                                       mountdir, fstype, blocksize, fslabel,
-                                      rmmountdir = True, tmpdir = "/tmp")
+                                      rmmountdir=True)
 
 
     def __format_filesystem(self):
@@ -445,11 +445,10 @@ class DiskMount(Mount):
 class ExtDiskMount(DiskMount):
     """A DiskMount object that is able to format/resize ext[23] filesystems."""
     def __init__(self, disk, mountdir, fstype, blocksize, fslabel,
-                 rmmountdir=True, tmpdir="/tmp"):
+                 rmmountdir=True):
         DiskMount.__init__(self, disk, mountdir, fstype, rmmountdir)
         self.blocksize = blocksize
         self.fslabel = "_" + fslabel
-        self.tmpdir = tmpdir
 
     def __format_filesystem(self):
         logging.info("Formating %s filesystem on %s" % (self.fstype, self.disk.device))
@@ -482,7 +481,7 @@ class ExtDiskMount(DiskMount):
         if size > current_size:
             self.disk.expand(size)
 
-        resize2fs(self.disk.lofile, size, tmpdir = self.tmpdir)
+        resize2fs(self.disk.lofile, size)
         return size
 
     def __create(self):
@@ -524,7 +523,7 @@ class ExtDiskMount(DiskMount):
         return int(parse_field(out, "Block count")) * self.blocksize
 
     def __resize_to_minimal(self):
-        resize2fs(self.disk.lofile, minimal = True, tmpdir = self.tmpdir)
+        resize2fs(self.disk.lofile, minimal=True)
         return self.__get_size_from_filesystem()
 
     def resparse(self, size = None):
@@ -614,8 +613,7 @@ class DeviceMapperSnapshot(object):
         except ValueError:
             raise SnapshotError("Failed to parse dmsetup status: " + out)
 
-def create_image_minimizer(path, image, compress_type, target_size = None,
-                           tmpdir = "/tmp"):
+def create_image_minimizer(path, image, compress_type, target_size=None):
     """
     Builds a copy-on-write image which can be used to
     create a device-mapper snapshot of an image where
@@ -643,9 +641,9 @@ def create_image_minimizer(path, image, compress_type, target_size = None,
         snapshot.create()
 
         if target_size is not None:
-            resize2fs(snapshot.path, target_size, tmpdir = tmpdir)
+            resize2fs(snapshot.path, target_size)
         else:
-            resize2fs(snapshot.path, minimal = True, tmpdir = tmpdir)
+            resize2fs(snapshot.path, minimal=True)
 
         cow_used = snapshot.get_cow_used()
     finally:

--- a/imgcreate/live.py
+++ b/imgcreate/live.py
@@ -356,8 +356,7 @@ class LiveImageCreatorBase(LoopImageCreator):
 
             if not self.skip_minimize:
                 create_image_minimizer(self.__isodir + "/LiveOS/osmin.img",
-                                       self._image, self.compress_type,
-                                       tmpdir = self.tmpdir)
+                                       self._image, self.compress_type)
 
             if self.skip_compression:
                 shutil.move(self._image, self.__isodir + "/LiveOS/ext3fs.img")


### PR DESCRIPTION
Remove unused tmpdir parameter in objects calling resize2fs().
Remove whitespace in default argument assignment.
