### PR TITLE
Allow the the image build to continue even if some policy missing on …

### DIFF
--- a/imgcreate/kickstart.py
+++ b/imgcreate/kickstart.py
@@ -460,10 +460,7 @@ class SelinuxConfig(KickstartConfig):
 
         rc = self.call(["/sbin/setfiles", "-p", "-e", "/proc", "-e", "/sys", "-e", "/dev", selinux.selinux_file_context_path(), "/"])
         if rc:
-            if ksselinux.selinux == ksconstants.SELINUX_ENFORCING:
-                raise errors.KickstartError("SELinux relabel failed.")
-            else:
-                logging.error("SELinux relabel failed.")
+            logging.error("SELinux relabel failed.")
 
     def apply(self, ksselinux):
         selinux_config = "/etc/selinux/config"


### PR DESCRIPTION
…host

When building and image it may have additional selinux modules
that are not part of the host system. In order to continue the build
we must ignore the setfiles error code

Signed-off-by: Tolik Litovsky tlitovsk@redhat.com
