### PR TITLE
symlink /etc/mtab to /proc/self/mounts breaks install to hard drive

### DIFF
--- a/imgcreate/creator.py
+++ b/imgcreate/creator.py
@@ -540,6 +540,11 @@ class ImageCreator(object):
         from the install root.
 
         """
+        try:
+            os.unlink(self._instroot + "/etc/mtab")
+        except OSError:
+            pass
+
         self.__destroy_selinuxfs()
 
         self._undo_bindmounts()


### PR DESCRIPTION
Do not leave /etc/mtab symlink to /proc/self/mounts in the
generated image. This is incompatible with at least two
packages in EL6:

* anaconda tries to write to /etc/mtab during postinstall
  stage in liveinst live image installation. When
  /etc/mtab points to read-only /proc/self/mounts,
  anaconda returns an error and the image cannot be
  installed to the hard drive.

* /sbin/mkdumprd from kexec-tools assumes that the output
  of mount command lists "/" mountpoint only once.
  When /etc/mtab points to /proc/self/mounts, mount command
  lists one entry "/" of type "rootfs" and one entry "/"
  of type ext4 (ext3, or other filesystem). This breaks
  the generation of initrd image for kdump.

Please see [rhbz #1347953](https://bugzilla.redhat.com/show_bug.cgi?id=1347953) for more information.