### PR TITLE
mktemp call fail. this commit fixes it.

### DIFF
--- a/tools/livecd-iso-to-pxeboot.sh
+++ b/tools/livecd-iso-to-pxeboot.sh
@@ -68,8 +68,8 @@ if [ -d tftpboot ]; then
 fi
 
 # Mount the ISO.
-CDMNT=$(mktemp -d /var/tmp/$0-mount.XXXXXX)
-STRIPPEDISO=$(mktemp -d /var/tmp/$0-stripped.XXXXXX)
+CDMNT=$(mktemp -d /var/tmp/$(basename $0)-mount.XXXXXX)
+STRIPPEDISO=$(mktemp -d /var/tmp/$(basename $0)-stripped.XXXXXX)
 mount -o loop "$ISO" $CDMNT || cleanup_error
 
 trap cleanup_error SIGINT SIGTERM


### PR DESCRIPTION
call to mktemp -d /var/tmp/$0-mount.XXXXXX fail because $0 is actually /bin/livecd-iso-to-pxe.sh so it fail with error message
mktemp: failed to create directory via template ‘/var/tmp//bin/livecd-iso-to-pxeboot-mount.XXXXXX’: No such file or directory

this ensure we use only basename part of $0 so it fix the problem.
