### PR TITLE
yuminst.LiveCDYum.runInstall: import yum.Errors

### DIFF
--- a/imgcreate/yuminst.py
+++ b/imgcreate/yuminst.py
@@ -197,6 +197,7 @@ class LiveCDYum(yum.YumBase):
 
 
     def runInstall(self):
+        import yum.Errors
         os.environ["HOME"] = "/"
         try:
             (res, resmsg) = self.buildTransaction()


### PR DESCRIPTION
On Fedora 24 with livecd-tools-23.3-1.fc24.x86_64 raising yum.Errors.RepoError without importing explicitly yum.Errors before the raise statement lead to:
 00:02:22.248 Traceback (most recent call last):
 00:02:22.248   File "/bin/livecd-creator", line 242, in <module>
 00:02:22.249     sys.exit(main())
 00:02:22.249   File "/bin/livecd-creator", line 218, in main
 00:02:22.249     creator.install()
 00:02:22.249   File "/usr/lib/python2.7/site-packages/imgcreate/creator.py", line 675, in install 
 00:02:22.251     ayum.runInstall()
 00:02:22.251   File "/usr/lib/python2.7/site-packages/imgcreate/yuminst.py", line 203, in runInstall
 00:02:22.251     except yum.Errors.RepoError, e:
 00:02:22.251 UnboundLocalError: local variable 'yum' referenced before assignment

Tracked on RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1365568